### PR TITLE
Moving tooling and testing into Docker

### DIFF
--- a/.dev/docker-compose.tests.yaml
+++ b/.dev/docker-compose.tests.yaml
@@ -1,12 +1,11 @@
-version: "3.9"
-
 services:
   leantime-dev:
     volumes:
-      - "../:/var/www/html"
-      - "./xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
-      - "./error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini"
-      - ${PWD}/test.env:/var/www/html/config/.env
+      - "${PWD}:/var/www/html"
+      - "${PWD}/.dev/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+      - "${PWD}/.dev/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini"
+      - "${PWD}/.dev/test.env:/var/www/html/config/.env"
+
   db:
     environment:
       MYSQL_DATABASE: leantime_test

--- a/.dev/docker-compose.tools.yaml
+++ b/.dev/docker-compose.tools.yaml
@@ -13,11 +13,12 @@ services:
       COMPOSER_IGNORE_PLATFORM_REQS: 1
 
   php:
-    <<: *tool-service
+    profiles: ["tools"]
     build: .
     container_name: leantime-php
+    working_dir: "/var/www/html"
     volumes:
-      - "${PWD}:/app"
+      - "${PWD}:/var/www/html"
       - "./xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
       - "./error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini"
 

--- a/.dev/docker-compose.tools.yaml
+++ b/.dev/docker-compose.tools.yaml
@@ -12,12 +12,12 @@ services:
       COMPOSER_IGNORE_PLATFORM_REQS: 1
 
   php:
-    <<: *tool-service
     build: .
+    <<: *tool-service
     volumes:
+      - "${PWD}:/app"
       - "./xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
       - "./error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini"
-      - ".env:/var/www/html/config/.env"
 
   npm:
     <<: *tool-service

--- a/.dev/docker-compose.tools.yaml
+++ b/.dev/docker-compose.tools.yaml
@@ -8,12 +8,14 @@ services:
   composer:
     <<: *tool-service
     image: composer
+    container_name: leantime-composer
     environment:
       COMPOSER_IGNORE_PLATFORM_REQS: 1
 
   php:
-    build: .
     <<: *tool-service
+    build: .
+    container_name: leantime-php
     volumes:
       - "${PWD}:/app"
       - "./xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
@@ -21,10 +23,12 @@ services:
 
   npm:
     <<: *tool-service
+    container_name: leantime-npm
     image: node:lts-alpine
     entrypoint: ["npm"]
 
   npx:
     <<: *tool-service
+    container_name: leantime-npx
     image: node:lts-alpine
     entrypoint: ["npx"]

--- a/.dev/docker-compose.tools.yaml
+++ b/.dev/docker-compose.tools.yaml
@@ -33,3 +33,18 @@ services:
     container_name: leantime-npx
     image: node:lts-alpine
     entrypoint: ["npx"]
+
+  selenium:
+    <<: *tool-service
+    container_name: leantime-selenium
+    image: selenium/standalone-firefox:latest
+    ports:
+      - "4444:4444"
+      - "7900:7900"
+
+  codeception:
+    <<: *tool-service
+    container_name: leantime-codeception
+    depends_on:
+      - selenium
+    image: codeception/codeception:latest

--- a/.dev/docker-compose.tools.yaml
+++ b/.dev/docker-compose.tools.yaml
@@ -1,0 +1,30 @@
+x-tool-service: &tool-service
+  profiles: ["tools"]
+  working_dir: "/app"
+  volumes:
+    - "${PWD}:/app"
+
+services:
+  composer:
+    <<: *tool-service
+    image: composer
+    environment:
+      COMPOSER_IGNORE_PLATFORM_REQS: 1
+
+  php:
+    <<: *tool-service
+    build: .
+    volumes:
+      - "./xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+      - "./error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini"
+      - ".env:/var/www/html/config/.env"
+
+  npm:
+    <<: *tool-service
+    image: node:lts-alpine
+    entrypoint: ["npm"]
+
+  npx:
+    <<: *tool-service
+    image: node:lts-alpine
+    entrypoint: ["npx"]

--- a/.dev/docker-compose.yaml
+++ b/.dev/docker-compose.yaml
@@ -1,23 +1,24 @@
-version: "3.9"
 networks:
   leantime:
-      external: false
-      driver: bridge
+    external: false
+    driver: bridge
+
 volumes:
   mysql:
   s3ninja-data:
 
 services:
   leantime-dev:
+    container_name: leantime-dev
     privileged: true
     build: .
     ports:
-      - "8090:8080"
+      - "127.0.0.1:8090:8080"
     volumes:
-     - "../:/var/www/html"
-     - "./xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
-     - "./error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini"
-     - ".env:/var/www/html/config/.env"
+      - "${PWD}:/var/www/html"
+      - "${PWD}/.dev/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini"
+      - "${PWD}/.dev/error_reporting.ini:/usr/local/etc/php/conf.d/error_reporting.ini"
+      - "${PWD}/.dev/.env:/var/www/html/config/.env"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:
@@ -25,8 +26,10 @@ services:
         condition: service_healthy
     networks:
       - leantime
+
   db:
     image: mysql:8.0
+    container_name: db
     ports:
       - 3306:3306
     environment:
@@ -43,8 +46,10 @@ services:
       interval: 5s
       timeout: 5s
       retries: 20
+
   maildev:
     image: maildev/maildev
+    container_name: maildev
     environment:
       - MAILDEV_SMTP_PORT=465
       - MAILDEV_WEB_PORT=8081
@@ -52,8 +57,10 @@ services:
       - 8081:8081
     networks:
       - leantime
+
   phpmyadmin:
     image: phpmyadmin
+    container_name: phpmyadmin
     ports:
       - 8082:80
     environment:
@@ -61,8 +68,10 @@ services:
       - PMA_PORT=3306
     networks:
       - leantime
+
   s3ninja:
     image: scireum/s3-ninja
+    container_name: s3ninja
     ports:
       - 8083:9000
     networks:

--- a/.dev/test.env
+++ b/.dev/test.env
@@ -13,7 +13,7 @@ LEAN_DB_HOST = 'db'                         # Database host
 LEAN_DB_USER = 'leantime'                                  # Database username
 LEAN_DB_PASSWORD = 'leantime'                              # Database password
 LEAN_DB_DATABASE = 'leantime_test'                         # Database name
-LEAN_DB_PORT = '3307'                              # Database port
+LEAN_DB_PORT = '3306'                              # Database port
 
 
 ## Optional Configuraiton, you may ommit these from your .env file

--- a/.dev/test.env
+++ b/.dev/test.env
@@ -13,7 +13,7 @@ LEAN_DB_HOST = 'db'                         # Database host
 LEAN_DB_USER = 'leantime'                                  # Database username
 LEAN_DB_PASSWORD = 'leantime'                              # Database password
 LEAN_DB_DATABASE = 'leantime_test'                         # Database name
-LEAN_DB_PORT = '3306'                              # Database port
+LEAN_DB_PORT = '3307'                              # Database port
 
 
 ## Optional Configuraiton, you may ommit these from your .env file

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ There are two ways to install a development setup of LeanTime. The first (but mo
 
 #### Development Installation via Docker ####
 
-For development, we use a dockerized development environment. You will need to have ``docker``, ``docker compose``, ``make``, ``composer``, ``git`` and ``npm`` installed.
+For development, we use a dockerized development environment. You will need to have ``docker``, ``docker compose``, and ``make`` installed.
 
 * Notes for Windows Environments:
     - Run all commands within the git bash terminal in order to utilize unix specific commands

--- a/makefile
+++ b/makefile
@@ -133,14 +133,17 @@ stop-dev:
 run-test: build-dev docker-clean-test set-folder-permissions
 	docker compose $(COMPOSE_FILES_TEST) up -d --build --remove-orphans
 
+stop-test:
+	docker compose $(COMPOSE_FILES_TEST) down -v
+
 acceptance-test: run-test create-test-database
 	$(run-php) ./vendor/bin/codecept run Acceptance --steps
-	docker compose $(COMPOSE_FILES_TEST) down -v
+	make stop-test
 
 acceptance-test-ci: run-test create-test-database
 	$(run-php) vendor/bin/codecept build
 	$(run-php) vendor/bin/codecept run Acceptance --steps
-	docker compose $(COMPOSE_FILES_TEST) down -v
+	make stop-test
 
 codesniffer:
 	$(run-php) ./vendor/squizlabs/php_codesniffer/bin/phpcs app

--- a/makefile
+++ b/makefile
@@ -127,6 +127,9 @@ docker-clean-test:
 run-dev: build-dev docker-clean set-folder-permissions
 	docker compose $(COMPOSE_FILES) up -d --build --remove-orphans
 
+stop-dev:
+	make docker-clean
+
 run-test: build-dev docker-clean-test set-folder-permissions
 	docker compose $(COMPOSE_FILES_TEST) up -d --build --remove-orphans
 

--- a/makefile
+++ b/makefile
@@ -124,10 +124,10 @@ docker-clean:
 docker-clean-test:
 	docker compose $(COMPOSE_FILES_TEST) down -v
 
-run-dev: build-dev docker-clean
+run-dev: build-dev docker-clean set-folder-permissions
 	docker compose $(COMPOSE_FILES) up -d --build --remove-orphans
 
-run-test: build-dev docker-clean-test
+run-test: build-dev docker-clean-test set-folder-permissions
 	docker compose $(COMPOSE_FILES_TEST) up -d --build --remove-orphans
 
 acceptance-test: run-test create-test-database

--- a/makefile
+++ b/makefile
@@ -9,6 +9,7 @@ run-tool := docker-compose -f .dev/docker-compose.tools.yaml run --rm
 run-composer := $(run-tool) composer
 run-npx := $(run-tool) npx
 run-npm := $(run-tool) npm
+run-php := $(run-tool) php
 
 install-deps-dev:
 	$(run-npm) install --only=dev
@@ -89,7 +90,7 @@ gendocs: # Requires github CLI (brew install gh)
 
 	# Generate the docs
 	phpDocumentor
-	php vendor/bin/leantime-documentor parse app --format=markdown --template=templates/markdown.php --output=builddocs/technical/hooks.md --memory-limit=-1
+	$(run-php) vendor/bin/leantime-documentor parse app --format=markdown --template=templates/markdown.php --output=builddocs/technical/hooks.md --memory-limit=-1
 
 	# create pull request
 	cd $(DOCS_DIR) && git switch -c "release/$(VERSION)"
@@ -109,10 +110,10 @@ run-dev: build-dev
 	cd .dev && docker-compose up --build --remove-orphans
 
 acceptance-test: build-dev
-	php vendor/bin/codecept run Acceptance --steps
+	$(run-php) vendor/bin/codecept run Acceptance --steps
 
 acceptance-test-ci: build-dev
-	php vendor/bin/codecept build
+	$(run-php) vendor/bin/codecept build
 ifeq ($(strip $(RUNNING_DOCKER_CONTAINERS)),)
 	@echo "No running docker containers found"
 else
@@ -123,7 +124,7 @@ ifeq ($(strip $(RUNNING_DOCKER_VOLUMES)),)
 else
 	docker volume rm $(RUNNING_DOCKER_VOLUMES)
 endif
-	php vendor/bin/codecept run Acceptance --steps
+	$(run-php) vendor/bin/codecept run Acceptance --steps
 
 codesniffer:
 	./vendor/squizlabs/php_codesniffer/bin/phpcs app

--- a/makefile
+++ b/makefile
@@ -9,19 +9,24 @@ RUNNING_DOCKER_VOLUMES := $(shell docker volume ls -q)
 UID := $(shell id -u)
 GID := $(shell id -g)
 
+# Base compose file
 COMPOSE_FILES := -f .dev/docker-compose.yaml
 
+# If local docker-compose file exists, add it to the command
 ifneq ("$(wildcard .dev/docker-compose.local.yaml)","")
 	COMPOSE_FILES += " -f .dev/docker-compose.local.yaml"
 endif
 
+# Compose files for tests
 COMPOSE_FILES_TEST := $(COMPOSE_FILES) -f .dev/docker-compose.tests.yaml
 
+# Command aliases for running tools in docker
 run-tool := docker compose -f .dev/docker-compose.tools.yaml run --rm --user "$(UID):$(GID)"
 run-composer := $(run-tool) composer
 run-npx := $(run-tool) npx
 run-npm := $(run-tool) npm
 run-php := $(run-tool) php
+# Alias for running SQL against the test database
 run-sql-test := docker compose $(COMPOSE_FILES_TEST) exec -T db mysql -hlocalhost -P3307 -uroot -pleantime -e
 
 install-deps-dev:

--- a/makefile
+++ b/makefile
@@ -5,19 +5,24 @@ DOCS_REPO:= git@github.com:Leantime/docs.git
 RUNNING_DOCKER_CONTAINERS:= $(shell docker ps -a -q)
 RUNNING_DOCKER_VOLUMES:= $(shell docker volume ls -q)
 
+run-tool := docker-compose -f .dev/docker-compose.tools.yaml run --rm
+run-composer := $(run-tool) composer
+run-npx := $(run-tool) npx
+run-npm := $(run-tool) npm
+
 install-deps-dev:
-	npm install --only=dev
-	composer install --optimize-autoloader
+	$(run-npm) install --only=dev
+	$(run-composer) install --optimize-autoloader
 
 install-deps:
-	npm install
-	composer install --no-dev --optimize-autoloader
+	$(run-npm) install
+	$(run-composer) install --no-dev --optimize-autoloader
 
 build: install-deps
-	npx mix --production
+	$(run-npx) mix --production
 
 build-dev: install-deps-dev
-	npx mix --production
+	$(run-npx) mix --production
 
 package: clean build
 	mkdir -p $(TARGET_DIR)
@@ -127,7 +132,7 @@ codesniffer-fix:
 	./vendor/squizlabs/php_codesniffer/bin/phpcbf app
 
 get-version:
-	@echo $(VERSION) 
+	@echo $(VERSION)
 
 .PHONY: install-deps build package clean run-dev
 

--- a/makefile
+++ b/makefile
@@ -129,14 +129,16 @@ docker-clean:
 docker-clean-test:
 	docker compose $(COMPOSE_FILES_TEST) down -v
 
-run-dev: build-dev docker-clean set-folder-permissions
+run-dev: build-dev docker-clean
 	docker compose $(COMPOSE_FILES) up -d --build --remove-orphans
+	make set-folder-permissions
 
 stop-dev:
 	make docker-clean
 
-run-test: build-dev docker-clean-test set-folder-permissions
+run-test: build-dev docker-clean-test
 	docker compose $(COMPOSE_FILES_TEST) up -d --build --remove-orphans
+	make set-folder-permissions
 
 stop-test:
 	docker compose $(COMPOSE_FILES_TEST) down -v
@@ -167,4 +169,3 @@ get-version:
 	@echo $(VERSION)
 
 .PHONY: install-deps build package clean run-dev run-test
-

--- a/makefile
+++ b/makefile
@@ -110,7 +110,7 @@ run-dev: build-dev
 	cd .dev && docker-compose up --build --remove-orphans
 
 acceptance-test: build-dev
-	$(run-php) vendor/bin/codecept run Acceptance --steps
+	$(run-php) ./vendor/bin/codecept run Acceptance --steps
 
 acceptance-test-ci: build-dev
 	$(run-php) vendor/bin/codecept build
@@ -127,10 +127,10 @@ endif
 	$(run-php) vendor/bin/codecept run Acceptance --steps
 
 codesniffer:
-	./vendor/squizlabs/php_codesniffer/bin/phpcs app
+	$(run-php) ./vendor/squizlabs/php_codesniffer/bin/phpcs app
 
 codesniffer-fix:
-	./vendor/squizlabs/php_codesniffer/bin/phpcbf app
+	$(run-php) ./vendor/squizlabs/php_codesniffer/bin/phpcbf app
 
 get-version:
 	@echo $(VERSION)

--- a/makefile
+++ b/makefile
@@ -143,7 +143,7 @@ run-test: build-dev docker-clean-test
 	make set-folder-permissions
 
 stop-test:
-	docker compose $(COMPOSE_FILES_TEST) down -v
+	make docker-clean-test
 
 acceptance-test: run-test create-test-database
 	$(run-php) ./vendor/bin/codecept run Acceptance --steps

--- a/makefile
+++ b/makefile
@@ -26,6 +26,8 @@ run-composer := $(run-tool) composer
 run-npx := $(run-tool) npx
 run-npm := $(run-tool) npm
 run-php := $(run-tool) php
+run-codeception := $(run-tool) codeception
+
 # Alias for running SQL against the test database
 run-sql-test := docker compose $(COMPOSE_FILES_TEST) exec -T db mysql -hlocalhost -P3307 -uroot -pleantime -e
 
@@ -148,8 +150,8 @@ acceptance-test: run-test create-test-database
 	make stop-test
 
 acceptance-test-ci: run-test create-test-database
-	$(run-php) vendor/bin/codecept build
-	$(run-php) vendor/bin/codecept run Acceptance --steps
+	$(run-codeception) build
+	$(run-codeception) run Acceptance --steps
 	make stop-test
 
 codesniffer:

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -152,8 +152,8 @@ $bootstrapper = get_class(new class {
 
     /**
      * Set folder permissions
-     * @todo Currently moving this to the makefile
      *
+     * @deprecated We do this in the makefile now
      * @access protected
      * @return void
      */
@@ -161,9 +161,8 @@ $bootstrapper = get_class(new class {
     {
         $this->createStep('Setting folder permissions on cache folder');
 
-        // Set file permissions
-        chown('/var/www/html/cache', 'www-data');
-        chgrp('/var/www/html/cache', 'www-data');
+        // We do this in the makefile now
+        return;
     }
 
     /**


### PR DESCRIPTION
I've made numerous changes that move dev tooling and running development environments almost entirely into docker, using the `makefile` to control it, and removing the need to have specific versions of PHP and tools installed on dev machines.

Right now the following is moved into docker containers:
* php
* composer
* npm
* npx

As part of this I have been and am continuing to remove anything that's calling external processes in the `tests/bootstrap.php` file, and instead moving it into calls in the makefile. So far these are done:
* Creating the test database
* Setting folder permissions inside the container

What needs to be done:
* Selenium - Considering moving this into a selenium docker container entirely, and bringing this up through the makefile

